### PR TITLE
Add "the focus"

### DIFF
--- a/draft-linker-diem-requirements.md
+++ b/draft-linker-diem-requirements.md
@@ -76,7 +76,7 @@ Additionally, this use case has the following requirements:
 
 # Other Use Cases and Requirements
 
-The initial DIEM efforts do not include the following use cases.
+The focus of the initial DIEM efforts does not include the following use cases.
 They are listed here for documentation and future reference.
 The requirements of these use cases are not complete and would need to be investigated further when addressing the use cases.
 


### PR DESCRIPTION
This exact phrasing was suggested by @cdeccio. I adopted most of the phrasing except for "the focus" because that had unclear implications to me. (Do we include them but just not focus on them? What does it mean to focus on some use cases but not nothers? Unclear.)

I open this PR for transparency. Casey, would be good to hear what you think of current phrasing!